### PR TITLE
Sum process sizes of the whole MainPID process tree.

### DIFF
--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -212,7 +211,7 @@ func ReadFileNoStat(filename string) ([]byte, error) {
 	defer f.Close()
 
 	reader := io.LimitReader(f, maxBufferSize)
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 // NewCPUAcct will locate and read the kernel's cpu accounting info for


### PR DESCRIPTION
Sum process sizes of the whole MainPID process tree.

Go is not my usual language, so I may have missed some idiom(s) in my changes.

But I think that this change is measuring memory usage the way I was expecting.