### PR TITLE
Read CPU stats from the cpu instead of the cpuacct controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / unreleased
 
+* read cpu statistics from the cpu controller instead of the cpuacct controller
+
 ## 0.5.0 / 2022-07-20
 
 Now released under the Prometheus Community

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -558,6 +558,18 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return nil
 	}
 
+	propCPUAcct, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, unitType, "CPUAccounting")
+	if err != nil {
+		return errors.Wrapf(err, errGetPropertyMsg, "CPUAccounting")
+	}
+	cpuAcct, ok := propCPUAcct.Value.Value().(bool)
+	if !ok {
+		return errors.Errorf(errConvertStringPropertyMsg, "CPUAccounting", propCPUAcct.Value.Value())
+	}
+	if !cpuAcct {
+		return nil
+	}
+
 	cpuUsage, err := NewCPUUsage(cgSubpath, c.logger)
 	if err != nil {
 		if unitType == "Socket" {


### PR DESCRIPTION
Fixes povilasv/systemd_exporter#34.

Signed-off-by: Nikolay Pelov <npelov@gmail.com>

Read cpu statistics from the cgroups v2 cpu controller instead of the cpuacct controller. This should work in both unified and hybrid modes of systemd. I am not sure if it will work under legacy mode and most likely will not work under cgroups v1. If this is a requirement then I should probably still keep the old code which reads from the cpuacct controller. Let me know if someone is interested in that.

Other than looking at the diff, I encourage folks to test the changes in different cgroups configurations. I compiled a linux binary based on 0.5.0 release including this fix in my [repo](https://github.com/pelov/systemd_exporter/releases).