### PR TITLE
Get CPU usage from cgroup v2 if available

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -569,7 +569,7 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return nil
 	}
 
-	cpuUsage, err := NewCPUAcct(cgSubpath, c.logger)
+	cpuStat, err := GetCPUStatOrAcct(cgSubpath, c.logger)
 	if err != nil {
 		if unitType == "Socket" {
 			level.Debug(c.logger).Log("msg", "unable to read SocketUnit CPU accounting information", "unit", unit.Name)
@@ -578,8 +578,8 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
 	}
 
-	userSeconds := float64(cpuUsage.UsageUserNanosecs()) / 1000000000.0
-	sysSeconds := float64(cpuUsage.UsageSystemNanosecs()) / 1000000000.0
+	userSeconds := float64(cpuStat.UserUsec) / 1000000.0
+	sysSeconds := float64(cpuStat.SystemUsec) / 1000000.0
 
 	ch <- prometheus.MustNewConstMetric(
 		c.unitCPUTotal, prometheus.CounterValue,


### PR DESCRIPTION
We currently try to read CPU usage from cpuacct, which is a cgroup v1 controller. On some systems, only cgroup v2 is enabled by default, and "cpuacct" is superseded by "cpu". When this is the case, systemd_exporter is not able to report CPU usage metrics, and instead logs a large amount of warning messages, for example:

    open /sys/fs/cgroup/system.slice/sshd.service/cpuacct.usage_all: no such file or directory

This patch adds support for cgroup v2 by looking for the presence of both cpuacct.usage_all (cgroup v1) and cpu.stat (cgroup v2), preferring the latter when available.

Reference: https://docs.kernel.org/admin-guide/cgroup-v2.html