### PR TITLE
expose more accounting metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Note that a number of unit types are filtered by default
 | systemd_unit_io_write_operations_total       | Counter     | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
 | systemd_unit_memory_bytes                    | Gauge       | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
 | systemd_unit_state                           | Gauge       | UNSTABLE | 5 per unit {state="activating/active/deactivating/failed/inactive} |
-| systemd_unit_tasks_current                   | Gauge       | UNSTABLE | 1 per service                                                      |
-| systemd_unit_tasks_max                       | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_unit_tasks_current                   | Gauge       | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
+| systemd_unit_tasks_max                       | Gauge       | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
 | systemd_unit_start_time_seconds              | Gauge       | UNSTABLE | 1 per service                                                      |
 | systemd_service_restart_total                | Gauge       | UNSTABLE | 1 per service                                                      |
-| systemd_service_ip_ingress_bytes             | Counter     | UNSTABLE | 1 per service                                                      |
-| systemd_service_ip_egress_bytes              | Counter     | UNSTABLE | 1 per service                                                      |
-| systemd_service_ip_ingress_packets_total     | Counter     | UNSTABLE | 1 per service                                                      |
-| systemd_service_ip_egress_packets_total      | Counter     | UNSTABLE | 1 per service                                                      |
+| systemd_service_ip_ingress_bytes             | Counter     | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
+| systemd_service_ip_egress_bytes              | Counter     | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
+| systemd_service_ip_ingress_packets_total     | Counter     | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
+| systemd_service_ip_egress_packets_total      | Counter     | UNSTABLE | 1 per slice, scope, service, socket, mount, or swap unit           |
 | systemd_socket_accepted_connections_total    | Counter     | UNSTABLE | 1 per socket                                                       |
 | systemd_socket_current_connections           | Gauge       | UNSTABLE | 1 per socket                                                       |
 | systemd_socket_refused_connections_total     | Gauge       | UNSTABLE | 1 per socket                                                       |

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -462,6 +462,18 @@ func (c *Collector) collectUnit(conn *dbus.Conn, ch chan<- prometheus.Metric, un
 		if err != nil {
 			logger.Warn(errUnitMetricsMsg, "err", err.Error())
 		}
+
+		err = c.collectServiceTasksMetrics(conn, ch, unit, unitType)
+		if err != nil {
+			logger.Warn(errUnitMetricsMsg, "err", err.Error())
+		}
+
+		if *enableIPAccountingMetrics {
+			err = c.collectIPAccountingMetrics(conn, ch, unit, unitType)
+			if err != nil {
+				logger.Warn(errUnitMetricsMsg, "err", err.Error())
+			}
+		}
 	}
 
 	switch unitType {
@@ -478,18 +490,6 @@ func (c *Collector) collectUnit(conn *dbus.Conn, ch chan<- prometheus.Metric, un
 
 		if *enableRestartsMetrics {
 			err = c.collectServiceRestartCount(conn, ch, unit)
-			if err != nil {
-				logger.Warn(errUnitMetricsMsg, "err", err.Error())
-			}
-		}
-
-		err = c.collectServiceTasksMetrics(conn, ch, unit)
-		if err != nil {
-			logger.Warn(errUnitMetricsMsg, "err", err.Error())
-		}
-
-		if *enableIPAccountingMetrics {
-			err = c.collectIPAccountingMetrics(conn, ch, unit)
 			if err != nil {
 				logger.Warn(errUnitMetricsMsg, "err", err.Error())
 			}
@@ -708,16 +708,17 @@ func (c *Collector) collectIOAccountingMetrics(conn *dbus.Conn, ch chan<- promet
 	return nil
 }
 
-func (c *Collector) collectIPAccountingMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {
+func (c *Collector) collectIPAccountingMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus, unitType string) error {
 	unitPropertyToPromDesc := map[string]*prometheus.Desc{
 		"IPIngressBytes":   c.ipIngressBytes,
 		"IPEgressBytes":    c.ipEgressBytes,
 		"IPIngressPackets": c.ipIngressPackets,
 		"IPEgressPackets":  c.ipEgressPackets,
 	}
+	unitType = capitalizeFirstCharacter(unitType)
 
 	for propertyName, desc := range unitPropertyToPromDesc {
-		property, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, "Service", propertyName)
+		property, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, unitType, propertyName)
 		if err != nil {
 			return fmt.Errorf(errGetPropertyMsg, propertyName, err)
 		}
@@ -739,8 +740,9 @@ func (c *Collector) collectIPAccountingMetrics(conn *dbus.Conn, ch chan<- promet
 
 // TODO either the unit should be called service_tasks, or it should work for all
 // units. It's currently named unit_task
-func (c *Collector) collectServiceTasksMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {
-	tasksCurrentCount, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, "Service", "TasksCurrent")
+func (c *Collector) collectServiceTasksMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus, unitType string) error {
+	unitType = capitalizeFirstCharacter(unitType)
+	tasksCurrentCount, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, unitType, "TasksCurrent")
 	if err != nil {
 		return fmt.Errorf(errGetPropertyMsg, "TasksCurrent", err)
 	}
@@ -757,7 +759,7 @@ func (c *Collector) collectServiceTasksMetrics(conn *dbus.Conn, ch chan<- promet
 			float64(currentCount), unit.Name)
 	}
 
-	tasksMaxCount, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, "Service", "TasksMax")
+	tasksMaxCount, err := conn.GetUnitTypePropertyContext(c.ctx, unit.Name, unitType, "TasksMax")
 	if err != nil {
 		return fmt.Errorf(errGetPropertyMsg, "TasksMax", err)
 	}


### PR DESCRIPTION
This PR follows up on #87. `systemd_exporter` already collects Task and IP Accounting metrics from systemd via dbus. This PR goes a step further to also collect IO, CPU, and Memory Accounting metrics.

The new metric names are noted in the README.

In my environment, this is preferable to deploying cAdvisor for at least a couple reasons:

1. systemd_exporter's more minimal featureset and configuration options suit us better--we just need this additional information that systemd itself already exposes. Getting e.g. high-level memory usage is plenty for us.
2. our team is already comfortable operating at the level of abstraction provided by systemd--services, slices, etc. We have some services that run under a specific parent slice, and it's useful for us to be able to look at both slice-wide and service-local metrics. Basically, it's useful to keep working with systemd's own abstractions, rather than going down a layer to cgroups.

### unit, rather than service

Since systemd has accounting metrics for more units than just services, these new metrics are collected for all relevant unit types. They are accordingly named `systemd_unit_*` instead of `systemd_service_*`. The unit types this data is collected for are those noted in [`systemd.resource-control(5)`](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#).

~~While this broader scope (no systemd .scope pun intended) for Accounting metrics would be relevant to the existing Task and IP Accounting metrics, I decided to leave them as-is to keep this PR's scope limited to adding new functionality. In the future, I do think it would make sense to modify `collectServiceTasksMetrics()` and `collectIPAccountingMetrics()` to work for these other unit types as well. Presumably, those metrics would keep their existing names (`systemd_service_*`) rather than changing the names; hard to imagine that breaking backwards compatibility would be worth the increased accuracy of a new name.~~

Task and IP Accounting metrics are now also collected for these unit types. The IP Accounting metrics are still called `systemd_service_*` instead of being changed to `systemd_unit_*` in order to preserve backwards compatibility.

### minor tweak

The only change I've made to existing functionality is to not collect IP Accounting metrics that are null/unset (i.e. set to `MaxUint64`). This accords with existing behavior in the codebase, and seems like clearly the right thing to do--rather than creating useless/irrelevant labelsets.

### dashboard

I've also taken a crack at adding these metrics to the dashboard that was mentioned [here](https://github.com/prometheus-community/systemd_exporter/issues/43#issuecomment-2661642680): https://grafana.com/grafana/dashboards/23844-systemd-exporter/

Edit: also added a multiselect dropdown for filtering units

### other

I have a [release with linux-amd64 built](https://github.com/jcgl17/systemd_exporter/releases) on my fork. It's just for my own use, but if anyone wants to quickly try out these changes without needing to build themselves, feel free to use it.