### PR TITLE
feat: add systemd_version metric

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -46,6 +46,12 @@ var (
 
 var unitStatesName = []string{"active", "activating", "deactivating", "inactive", "failed"}
 
+// systemdVersionRE matches the numeric portion of a systemd version string.
+// systemd versions are >= 3 digits (e.g. "255", "255.4"), possibly wrapped in
+// extra text like "249 (249.11-0ubuntu3)". Mirrors node_exporter so the exposed
+// value stays comparable across the two exporters.
+var systemdVersionRE = regexp.MustCompile(`[0-9]{3,}(\.[0-9]+)?`)
+
 var (
 	errGetPropertyMsg           = "couldn't get unit's %s property: %w"
 	errConvertUint64PropertyMsg = "couldn't convert unit's %s property %v to uint64"
@@ -60,6 +66,7 @@ type Collector struct {
 	logger                        *slog.Logger
 	systemdBootMonotonic          *prometheus.Desc
 	systemdBootTime               *prometheus.Desc
+	systemdVersionDesc            *prometheus.Desc
 	unitCPUTotal                  *prometheus.Desc
 	unitState                     *prometheus.Desc
 	unitInfo                      *prometheus.Desc
@@ -97,6 +104,10 @@ func NewCollector(logger *slog.Logger) (*Collector, error) {
 	systemdBootTime := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "boot_time_seconds"),
 		"Systemd boot stage timestamps", []string{"stage"}, nil,
+	)
+	systemdVersion := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "version"),
+		"Detected systemd version", []string{"version"}, nil,
 	)
 	// Type is labeled twice e.g. name="foo.service" and type="service" to maintain compatibility
 	// with users before we started exporting type label
@@ -230,6 +241,7 @@ func NewCollector(logger *slog.Logger) (*Collector, error) {
 		logger:                        logger,
 		systemdBootMonotonic:          systemdBootMonotonic,
 		systemdBootTime:               systemdBootTime,
+		systemdVersionDesc:            systemdVersion,
 		unitCPUTotal:                  unitCPUTotal,
 		unitState:                     unitState,
 		unitInfo:                      unitInfo,
@@ -270,6 +282,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 func (c *Collector) Describe(desc chan<- *prometheus.Desc) {
 	desc <- c.systemdBootMonotonic
 	desc <- c.systemdBootTime
+	desc <- c.systemdVersionDesc
 	desc <- c.unitCPUTotal
 	desc <- c.unitState
 	desc <- c.unitInfo
@@ -312,6 +325,11 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 	err = c.collectWatchdogMetrics(conn, ch)
 	if err != nil {
 		c.logger.Debug("Failed to collect watchdog metrics", "err", err.Error())
+	}
+
+	err = c.collectVersion(conn, ch)
+	if err != nil {
+		c.logger.Debug("Failed to collect systemd version", "err", err.Error())
 	}
 
 	allUnits, err := conn.ListUnitsContext(c.ctx)
@@ -381,6 +399,37 @@ func (c *Collector) collectBootStageTimestamps(conn *dbus.Conn, ch chan<- promet
 			stage)
 	}
 
+	return nil
+}
+
+// parseSystemdVersion extracts the numeric systemd version and the full version
+// string from the raw manager "Version" property. GetManagerProperty returns the
+// D-Bus variant's string form, which for a string property is wrapped in quotes.
+func parseSystemdVersion(raw string) (float64, string, error) {
+	version := strings.Trim(raw, `"`)
+	num := systemdVersionRE.FindString(version)
+	parsed, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return 0, version, fmt.Errorf("couldn't parse systemd version %q: %w", version, err)
+	}
+	return parsed, version, nil
+}
+
+// collectVersion exposes the running systemd version as systemd_version, with the
+// full version string as a label and the numeric version as the value (matching
+// node_exporter's node_systemd_version).
+func (c *Collector) collectVersion(conn *dbus.Conn, ch chan<- prometheus.Metric) error {
+	raw, err := conn.GetManagerProperty("Version")
+	if err != nil {
+		return err
+	}
+
+	parsed, version, err := parseSystemdVersion(raw)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.systemdVersionDesc, prometheus.GaugeValue, parsed, version)
 	return nil
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systemd
+
+import "testing"
+
+func TestParseSystemdVersion(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		wantNum     float64
+		wantVersion string
+	}{
+		{"plain quoted", `"255"`, 255, "255"},
+		{"minor version", `"255.4"`, 255.4, "255.4"},
+		{"distro suffix", `"255.4-1ubuntu8.6"`, 255.4, "255.4-1ubuntu8.6"},
+		{"parenthesised full string", `"249 (249.11-0ubuntu3.12)"`, 249, "249 (249.11-0ubuntu3.12)"},
+		{"unquoted", "252", 252, "252"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			num, version, err := parseSystemdVersion(tc.raw)
+			if err != nil {
+				t.Fatalf("parseSystemdVersion(%q) unexpected error: %v", tc.raw, err)
+			}
+			if num != tc.wantNum {
+				t.Errorf("num = %v, want %v", num, tc.wantNum)
+			}
+			if version != tc.wantVersion {
+				t.Errorf("version = %q, want %q", version, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestParseSystemdVersionErrors(t *testing.T) {
+	// No 3+ digit version number to parse -> error rather than a bogus 0 metric.
+	for _, raw := range []string{`""`, `"unknown"`, "", "v42"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, _, err := parseSystemdVersion(raw); err == nil {
+				t.Errorf("parseSystemdVersion(%q) expected error, got nil", raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #27

Exposes the running systemd version as the \`systemd_version\` gauge (full version string as a \`version\` label, numeric version as the value, mirroring node_exporter's \`node_systemd_version\`), read from the systemd manager \`Version\` D-Bus property. Parsing is factored into a pure \`parseSystemdVersion()\` helper with unit tests. Verified against a live exporter run on systemd 255: \`systemd_version{version="255.4-1ubuntu8.16"} 255.4\`.