### PR TITLE
logind: initial collector implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Name     | Description |
 --systemd.collector.enable-restart-count | Enables service restart count metrics. This feature only works with systemd 235 and above.
 --systemd.collector.enable-file-descriptor-size | Enables file descriptor size metrics. Systemd Exporter needs access to /proc/X/fd files.
 --systemd.collector.enable-ip-accounting | Enables service ip accounting metrics. This feature only works with systemd 235 and above.
+--systemd.collector.enable-logind | Enable systemd-logind metrics.
 
 Of note, there is no customized support for `.snapshot` (removed in systemd v228), `.busname` (only present on systems using kdbus), `generated` (created via generators), `transient` (created during systemd-run) have no special support. 
 
@@ -104,6 +105,9 @@ Note that a number of unit types are filtered by default
 | systemd_watchdog_last_ping_monotonic_seconds | Gauge       | UNSTABLE | 1                                                                  |
 | systemd_watchdog_last_ping_time_seconds      | Gauge       | UNSTABLE | 1                                                                  |
 | systemd_watchdog_runtime_seconds             | Gauge       | UNSTABLE | 1                                                                  |
+| systemd_logind_sessions_current              | Gauge       | UNSTABLE | 1                                                                  |
+| systemd_logind_users_current                 | Gauge       | UNSTABLE | 1                                                                  |
+| systemd_logind_scrape_success                | Gauge       | UNSTABLE | 1                                                                  |
 
 ## Configuration
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/systemd_exporter/systemd"
+	"github.com/prometheus-community/systemd_exporter/systemd/logind"
 	"github.com/prometheus-community/systemd_exporter/systemd/resolved"
 	"github.com/prometheus/client_golang/prometheus"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
@@ -46,6 +47,7 @@ func main() {
 			"Maximum number of parallel scrape requests. Use 0 to disable.",
 		).Default("40").Int()
 		enableResolvedgMetrics = kingpin.Flag("systemd.collector.enable-resolved", "Enable systemd-resolved statistics").Bool()
+		enableLogindMetrics    = kingpin.Flag("systemd.collector.enable-logind", "Enable systemd-logind statistics").Bool()
 
 		toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9558")
 	)
@@ -98,6 +100,18 @@ func main() {
 
 		if err := r.Register(resolvedCollector); err != nil {
 			logger.Error("Couldn't register resolved collector", "err", err)
+			os.Exit(1)
+		}
+	}
+	if *enableLogindMetrics {
+		logindCollector, err := logind.NewCollector(logger)
+		if err != nil {
+			logger.Error("Couldn't create logind collector", "err", err)
+			os.Exit(1)
+		}
+
+		if err := r.Register(logindCollector); err != nil {
+			logger.Error("Couldn't register logind collector", "err", err)
 			os.Exit(1)
 		}
 	}

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logind
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/coreos/go-systemd/v22/login1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "systemd"
+	subsystem = "logind"
+)
+
+var (
+	logindSessions = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "sessions_current"),
+		"Number of sessions Logind is currently tracking",
+		nil, nil,
+	)
+	logindUsers = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "users_current"),
+		"Number of users Logind is currently tracking",
+		nil, nil,
+	)
+	logindScrapeSuccess = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "scrape_success"),
+		"Whether the metric retrieval succeeded",
+		nil, nil,
+	)
+)
+
+type Collector struct {
+	ctx    context.Context
+	logger *slog.Logger
+}
+
+// NewCollector returns a new Collector providing logind statistics
+func NewCollector(logger *slog.Logger) (*Collector, error) {
+
+	ctx := context.TODO()
+	return &Collector{
+		ctx:    ctx,
+		logger: logger,
+	}, nil
+}
+
+// Collect gathers metrics from logind
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	err := c.collect(ch)
+	if err != nil {
+		c.logger.Error("error collecting logind metrics",
+			"err", err.Error())
+		ch <- prometheus.MustNewConstMetric(logindScrapeSuccess, prometheus.GaugeValue, 0)
+	} else {
+		ch <- prometheus.MustNewConstMetric(logindScrapeSuccess, prometheus.GaugeValue, 1)
+	}
+}
+
+// Describe gathers descriptions of metrics
+func (c *Collector) Describe(desc chan<- *prometheus.Desc) {
+	desc <- logindSessions
+	desc <- logindUsers
+	desc <- logindScrapeSuccess
+}
+
+func (c *Collector) collect(ch chan<- prometheus.Metric) error {
+	conn, err := login1.New()
+	if err != nil {
+		return fmt.Errorf("couldn't get logind connection: %w", err)
+	}
+	defer conn.Close()
+
+	sessions, err := conn.ListSessionsContext(c.ctx)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(logindSessions, prometheus.GaugeValue,
+		float64(len(sessions)))
+
+	users, err := conn.ListUsersContext(c.ctx)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(logindUsers, prometheus.GaugeValue,
+		float64(len(users)))
+
+	return nil
+}


### PR DESCRIPTION
similar to the systemd-resolved collector, but for systemd-logind. currently only session and user count are collected; information about inhibitors and seats are omitted as the systemd library currently does not provide an API for those objects (version 22)