### PR TITLE
feat: add flags to toggle start time and task metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Name     | Description |
 --systemd.collector.enable-restart-count | Enables service restart count metrics. This feature only works with systemd 235 and above.
 --systemd.collector.enable-file-descriptor-size | Enables file descriptor size metrics. Systemd Exporter needs access to /proc/X/fd files.
 --systemd.collector.enable-ip-accounting | Enables service ip accounting metrics. This feature only works with systemd 235 and above.
+--systemd.collector.enable-start-time-metrics | Enables service start time metrics. Enabled by default, disable with `--no-systemd.collector.enable-start-time-metrics`.
+--systemd.collector.enable-task-metrics | Enables service task metrics. Enabled by default, disable with `--no-systemd.collector.enable-task-metrics`.
 
 Of note, there is no customized support for `.snapshot` (removed in systemd v228), `.busname` (only present on systems using kdbus), `generated` (created via generators), `transient` (created during systemd-run) have no special support. 
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -42,6 +42,8 @@ var (
 	systemdUser               = kingpin.Flag("systemd.collector.user", "Connect to the user systemd instance.").Bool()
 	enableRestartsMetrics     = kingpin.Flag("systemd.collector.enable-restart-count", "Enables service restart count metrics. This feature only works with systemd 235 and above.").Bool()
 	enableIPAccountingMetrics = kingpin.Flag("systemd.collector.enable-ip-accounting", "Enables service ip accounting metrics. This feature only works with systemd 235 and above.").Bool()
+	enableStartTimeMetrics    = kingpin.Flag("systemd.collector.enable-start-time-metrics", "Enables service start time metrics. Enabled by default, disable with --no-systemd.collector.enable-start-time-metrics.").Default("true").Bool()
+	enableTaskMetrics         = kingpin.Flag("systemd.collector.enable-task-metrics", "Enables service task metrics. Enabled by default, disable with --no-systemd.collector.enable-task-metrics.").Default("true").Bool()
 )
 
 var unitStatesName = []string{"active", "activating", "deactivating", "inactive", "failed"}
@@ -455,9 +457,11 @@ func (c *Collector) collectUnit(conn *dbus.Conn, ch chan<- prometheus.Metric, un
 			logger.Warn(errUnitMetricsMsg, "err", err.Error())
 		}
 
-		err = c.collectServiceStartTimeMetrics(conn, ch, unit)
-		if err != nil {
-			logger.Warn(errUnitMetricsMsg, "err", err.Error())
+		if *enableStartTimeMetrics {
+			err = c.collectServiceStartTimeMetrics(conn, ch, unit)
+			if err != nil {
+				logger.Warn(errUnitMetricsMsg, "err", err.Error())
+			}
 		}
 
 		if *enableRestartsMetrics {
@@ -467,9 +471,11 @@ func (c *Collector) collectUnit(conn *dbus.Conn, ch chan<- prometheus.Metric, un
 			}
 		}
 
-		err = c.collectServiceTasksMetrics(conn, ch, unit)
-		if err != nil {
-			logger.Warn(errUnitMetricsMsg, "err", err.Error())
+		if *enableTaskMetrics {
+			err = c.collectServiceTasksMetrics(conn, ch, unit)
+			if err != nil {
+				logger.Warn(errUnitMetricsMsg, "err", err.Error())
+			}
 		}
 
 		if *enableIPAccountingMetrics {


### PR DESCRIPTION
Closes #30.

Adds the two flags the issue asks for, mirroring the collector's existing
opt-in flags:

- `--systemd.collector.enable-start-time-metrics` gates
  `collectServiceStartTimeMetrics()`
- `--systemd.collector.enable-task-metrics` gates
  `collectServiceTasksMetrics()`

Both default to **true**, which is the one place this diverges from
`--systemd.collector.enable-restart-count` and
`--systemd.collector.enable-ip-accounting`. Those two guard metrics that were
opt-in from the start, whereas start time and task metrics are collected
unconditionally today, so defaulting the new flags to false would silently drop
`systemd_unit_start_time_seconds`, `systemd_unit_tasks_current` and
`systemd_unit_tasks_max` from every existing deployment. Kingpin generates
`--no-systemd.collector.enable-task-metrics` for turning them off. Flag names
match node_exporter's `--collector.systemd.enable-task-metrics` and
`--collector.systemd.enable-start-time-metrics`, which the README already
points readers at.

Say the word if you would rather have them default to false for a major
release and I will flip them.

No unit test: the change is flag gating around two existing collectors, and
nothing in it is testable without a live D-Bus connection. Verified by running
the binary instead.

## Verification

Built and run against systemd 255 on Linux 6.17.0-35. `go build`, `go vet` and
`go test -race ./...` are green.

Default (no flags), scraping `:9558`:

```
systemd_unit_start_time_seconds   174 series
systemd_unit_tasks_{current,max}  219 series
metric families                    20
```

With both disabled:

```
$ ./systemd_exporter --no-systemd.collector.enable-start-time-metrics \
                     --no-systemd.collector.enable-task-metrics

systemd_unit_start_time_seconds     0 series
systemd_unit_tasks_{current,max}    0 series
metric families                    17
```

Diffing the `# HELP` lines of the two scrapes shows exactly three families
gone and nothing else changed:

```
< systemd_unit_start_time_seconds
< systemd_unit_tasks_current
< systemd_unit_tasks_max
```
