### PR TITLE
docs: drop removed flag, use node-exporter's names in the comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ should look into process-exporter.
 There is overlap between these three exporters, so make sure to read the documents if you use multiple. 
 
 For example, if you are using systemd-exporter, then you should *not* enable these flags in node-exporter 
-as we already expose identical metrics by default: `--systemd.collector.enable-task-metrics --systemd.collector.enable-restarts-metrics
- --systemd.collector.enable-start-time-metrics`. process-exporter has a concept of logically grouping
+as we already expose identical metrics by default: `--collector.systemd.enable-task-metrics --collector.systemd.enable-restarts-metrics
+ --collector.systemd.enable-start-time-metrics`. Those are node-exporter's flag names; this exporter's
+own flags use the `--systemd.collector.` prefix listed below. process-exporter has a concept of logically grouping
 processes according to the process names. This is a bottom-up variant of logical process grouping, while 
 systemd's approach is top-down (e.g. groups are named and then processes are launched in them). The systemd
 approach provides much stronger guarantees that no processes/threads are "missing" from your group, but 
@@ -54,7 +55,6 @@ Optional Flags:
 Name     | Description | 
 ---------|-------------|
 --systemd.collector.enable-restart-count | Enables service restart count metrics. This feature only works with systemd 235 and above.
---systemd.collector.enable-file-descriptor-size | Enables file descriptor size metrics. Systemd Exporter needs access to /proc/X/fd files.
 --systemd.collector.enable-ip-accounting | Enables service ip accounting metrics. This feature only works with systemd 235 and above.
 
 Of note, there is no customized support for `.snapshot` (removed in systemd v228), `.busname` (only present on systems using kdbus), `generated` (created via generators), `transient` (created during systemd-run) have no special support. 


### PR DESCRIPTION
Closes #177. Answers most of #188.

Two documentation bugs, both verified against a binary built from main (`86e25c6`) on
systemd 255, Linux 6.17.0-35:

**1. `--systemd.collector.enable-file-descriptor-size` does not exist.**

```
$ ./systemd_exporter --help 2>&1 | grep -c 'enable-file-descriptor-size'
0
$ ./systemd_exporter --systemd.collector.enable-file-descriptor-size
systemd_exporter: error: unknown long flag '--systemd.collector.enable-file-descriptor-size', try --help
```

It was removed in #68 ("Remove broken metrics collection", Dec 2022) along with the rest of
the process metrics. That commit edits `README.md`, but `git show 627dc49 -- README.md` does
not touch the Optional Flags table, so the row outlived the flag and the docs have been wrong
since v0.5.0. That is exactly what #177 hit.

**2. The flags quoted in "Relation to Node and Process Exporter" are node-exporter's, written
with this exporter's prefix.**

The paragraph tells you not to enable them *in node-exporter*, so the names should be
node-exporter's. From `prometheus/node_exporter/collector/systemd_linux.go`:

```go
enableTaskMetrics      = kingpin.Flag("collector.systemd.enable-task-metrics", ...)
enableRestartsMetrics  = kingpin.Flag("collector.systemd.enable-restarts-metrics", ...)
enableStartTimeMetrics = kingpin.Flag("collector.systemd.enable-start-time-metrics", ...)
```

That is where #188's question comes from: `--systemd.collector.enable-restarts-metrics` was
never a flag of this exporter. It is node-exporter's `--collector.systemd.enable-restarts-metrics`,
and this exporter's equivalent is `--systemd.collector.enable-restart-count`. Both exist, they
just belong to different exporters. Added one sentence naming whose prefix is whose so the next
reader does not have to work that out.

**Left out on purpose:** the missing `--systemd.collector.enable-resolved` row, the other half
of #188. @egmc has had that in #123 since January 2024, so it is theirs; it only needs a rebase
(the table it edits was realigned since). Happy to fold it in here instead if #123 has gone
stale, but it seemed wrong to duplicate someone else's open PR.

Also undocumented, and out of scope here: `--systemd.collector.private` and
`--systemd.collector.user`, which are connection options rather than the version-gated feature
flags this table is about. Say the word and I will add them in a follow-up.

Docs only, no code change.